### PR TITLE
Snappy Compresion on Primitives

### DIFF
--- a/bdb/blocknodedisk.go
+++ b/bdb/blocknodedisk.go
@@ -1,6 +1,7 @@
 package bdb
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -17,10 +18,18 @@ type BlockNodeDisk struct {
 
 // Marshal encodes de data
 func (bnd *BlockNodeDisk) Marshal() ([]byte, error) {
-	return ssz.Marshal(bnd)
+	b, err := ssz.Marshal(bnd)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data
 func (bnd *BlockNodeDisk) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, bnd)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, bnd)
 }

--- a/bdb/state.go
+++ b/bdb/state.go
@@ -244,7 +244,6 @@ func (brt *BlockDBReadTransaction) GetBlockRow(c chainhash.Hash) (*BlockNodeDisk
 	if err != nil {
 		return nil, err
 	}
-
 	d := new(BlockNodeDisk)
 	err = d.Unmarshal(diskSer)
 	return d, err

--- a/bls/combined.go
+++ b/bls/combined.go
@@ -3,6 +3,7 @@ package bls
 import (
 	"fmt"
 
+	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
 )
 
@@ -20,7 +21,11 @@ func (cs *CombinedSignature) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (cs *CombinedSignature) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, cs)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, cs)
 }
 
 // NewCombinedSignature creates a new combined signature

--- a/bls/combined.go
+++ b/bls/combined.go
@@ -16,7 +16,11 @@ type CombinedSignature struct {
 
 // Marshal encodes the data.
 func (cs *CombinedSignature) Marshal() ([]byte, error) {
-	return ssz.Marshal(cs)
+	b, err := ssz.Marshal(cs)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/bls/multisig.go
+++ b/bls/multisig.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/params"
 	"github.com/olympus-protocol/ogen/utils/bech32"
 	"github.com/olympus-protocol/ogen/utils/bitfield"
@@ -27,7 +28,11 @@ func (m *Multipub) Marshal() []byte {
 
 // Unmarshal decodes the data.
 func (m *Multipub) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 // NewMultipub constructs a new multi-pubkey.
@@ -114,7 +119,11 @@ func (m *Multisig) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (m *Multisig) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 // NewMultisig creates a new blank multisig.

--- a/bls/multisig.go
+++ b/bls/multisig.go
@@ -22,8 +22,11 @@ type Multipub struct {
 
 // Marshal encodes the data.
 func (m *Multipub) Marshal() []byte {
-	b, _ := ssz.Marshal(m)
-	return b
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return snappy.Encode(nil, b)
 }
 
 // Unmarshal decodes the data.
@@ -114,7 +117,11 @@ type Multisig struct {
 
 // Marshal encodes the data.
 func (m *Multisig) Marshal() ([]byte, error) {
-	return ssz.Marshal(m)
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/chain/index/txs.go
+++ b/chain/index/txs.go
@@ -3,6 +3,7 @@ package index
 import (
 	"path"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 	"go.etcd.io/bbolt"
@@ -126,7 +127,11 @@ func (tl *TxLocator) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (tl *TxLocator) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, tl)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, tl)
 }
 
 // NewTxIndex returns/creates a new tx index database

--- a/chain/index/txs.go
+++ b/chain/index/txs.go
@@ -122,7 +122,11 @@ type TxLocator struct {
 
 // Marshal encodes the data.
 func (tl *TxLocator) Marshal() ([]byte, error) {
-	return ssz.Marshal(tl)
+	b, err := ssz.Marshal(tl)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ferranbt/fastssz v0.0.0-20200514094935-99fccaf93472
 	github.com/go-test/deep v1.0.7
 	github.com/golang/protobuf v1.4.2
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/grpc-ecosystem/grpc-gateway v1.14.6
 	github.com/libp2p/go-libp2p v0.10.0
 	github.com/libp2p/go-libp2p-core v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -46,7 +47,11 @@ func (h *MessageHeader) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (h *MessageHeader) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, h)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, h)
 }
 
 func makeEmptyMessage(command string) (Message, error) {

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -47,11 +46,7 @@ func (h *MessageHeader) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (h *MessageHeader) Unmarshal(b []byte) error {
-	d, err := snappy.Decode(nil, b)
-	if err != nil {
-		return err
-	}
-	return ssz.Unmarshal(d, h)
+	return ssz.Unmarshal(b, h)
 }
 
 func makeEmptyMessage(command string) (Message, error) {

--- a/p2p/msg_addr.go
+++ b/p2p/msg_addr.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
 )
 
@@ -18,7 +19,11 @@ func (m *MsgAddr) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (m *MsgAddr) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 func (m *MsgAddr) Command() string {

--- a/p2p/msg_addr.go
+++ b/p2p/msg_addr.go
@@ -14,7 +14,11 @@ type MsgAddr struct {
 
 // Marshal serializes the data to bytes
 func (m *MsgAddr) Marshal() ([]byte, error) {
-	return ssz.Marshal(m)
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserializes the data

--- a/p2p/msg_block.go
+++ b/p2p/msg_block.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/primitives"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -19,7 +20,11 @@ func (m *MsgBlocks) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (m *MsgBlocks) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 func (m *MsgBlocks) Command() string {

--- a/p2p/msg_block.go
+++ b/p2p/msg_block.go
@@ -15,7 +15,11 @@ type MsgBlocks struct {
 
 // Marshal serializes the data to bytes
 func (m *MsgBlocks) Marshal() ([]byte, error) {
-	return ssz.Marshal(m)
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserializes the data

--- a/p2p/msg_getblocks.go
+++ b/p2p/msg_getblocks.go
@@ -13,7 +13,11 @@ type MsgGetBlocks struct {
 
 // Marshal serializes the data to bytes
 func (m *MsgGetBlocks) Marshal() ([]byte, error) {
-	return ssz.Marshal(m)
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserializes the data

--- a/p2p/msg_getblocks.go
+++ b/p2p/msg_getblocks.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -17,7 +18,11 @@ func (m *MsgGetBlocks) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (m *MsgGetBlocks) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 func (m *MsgGetBlocks) Command() string {

--- a/p2p/msg_version.go
+++ b/p2p/msg_version.go
@@ -15,7 +15,11 @@ type MsgVersion struct {
 
 // Marshal serializes the data to bytes
 func (m *MsgVersion) Marshal() ([]byte, error) {
-	return ssz.Marshal(m)
+	b, err := ssz.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserializes the data

--- a/p2p/msg_version.go
+++ b/p2p/msg_version.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"time"
 
+	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
 )
 
@@ -19,7 +20,11 @@ func (m *MsgVersion) Marshal() ([]byte, error) {
 
 // Unmarshal deserializes the data
 func (m *MsgVersion) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, m)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, m)
 }
 
 func (m *MsgVersion) Command() string {

--- a/peers/syncprotocol.go
+++ b/peers/syncprotocol.go
@@ -276,7 +276,7 @@ func (sp *SyncProtocol) handleVersion(id peer.ID, msg p2p.Message) error {
 				sp.syncInfo.syncing = false
 				sp.syncMutex.Unlock()
 			}
-			
+
 		}(theirVersion, ourVersion)
 	}
 	return nil

--- a/primitives/block.go
+++ b/primitives/block.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -26,12 +27,20 @@ type Block struct {
 
 // Marshal encodes the block.
 func (b *Block) Marshal() ([]byte, error) {
-	return ssz.Marshal(b)
+	bd, err := ssz.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, bd), nil
 }
 
 // Unmarshal decodes the block.
 func (b *Block) Unmarshal(by []byte) error {
-	return ssz.Unmarshal(by, b)
+	d, err := snappy.Decode(nil, by)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, b)
 }
 
 // Hash calculates the hash of the block.

--- a/primitives/blockheader.go
+++ b/primitives/blockheader.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
 )
@@ -27,12 +28,20 @@ type BlockHeader struct {
 
 // Marshal encodes the data.
 func (bh *BlockHeader) Marshal() ([]byte, error) {
-	return ssz.Marshal(bh)
+	b, err := ssz.Marshal(bh)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (bh *BlockHeader) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, bh)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, bh)
 }
 
 // Hash calculates the hash of the block header.

--- a/primitives/coins_state.go
+++ b/primitives/coins_state.go
@@ -2,6 +2,7 @@ package primitives
 
 import (
 	fastssz "github.com/ferranbt/fastssz"
+	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
 )
 
@@ -27,12 +28,20 @@ type CoinsState struct {
 
 // Marshal serialize to bytes the struct
 func (u *CoinsState) Marshal() ([]byte, error) {
-	return ssz.Marshal(u)
+	b, err := ssz.Marshal(u)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserialize the bytes to struct
 func (u *CoinsState) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, u)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, u)
 }
 
 // MarshalSSZ uses the fastssz interface to override the ssz Marshal function

--- a/primitives/deposit.go
+++ b/primitives/deposit.go
@@ -66,7 +66,11 @@ type DepositData struct {
 
 // Marshal encodes the data.
 func (d *DepositData) Marshal() ([]byte, error) {
-	return ssz.Marshal(d)
+	b, err := ssz.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/primitives/deposit.go
+++ b/primitives/deposit.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
@@ -20,12 +21,20 @@ type Deposit struct {
 
 // Marshal encodes the data.
 func (d *Deposit) Marshal() ([]byte, error) {
-	return ssz.Marshal(d)
+	b, err := ssz.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (d *Deposit) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, d)
+	de, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(de, d)
 }
 
 func (d *Deposit) GetPublicKey() (*bls.PublicKey, error) {
@@ -62,7 +71,11 @@ func (d *DepositData) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (d *DepositData) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, d)
+	de, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(de, d)
 }
 
 func (d *DepositData) GetPublicKey() (*bls.PublicKey, error) {

--- a/primitives/epochtransition.go
+++ b/primitives/epochtransition.go
@@ -272,7 +272,11 @@ type EpochReceipt struct {
 
 // Marshal encodes the data.
 func (d *EpochReceipt) Marshal() ([]byte, error) {
-	return ssz.Marshal(d)
+	b, err := ssz.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/primitives/epochtransition.go
+++ b/primitives/epochtransition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/params"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
@@ -276,7 +277,11 @@ func (d *EpochReceipt) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (d *EpochReceipt) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, d)
+	de, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(de, d)
 }
 
 func (e EpochReceipt) TypeString() string {

--- a/primitives/exit.go
+++ b/primitives/exit.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
@@ -27,12 +28,20 @@ func (e *Exit) GetSignature() (*bls.Signature, error) {
 
 // Marshal encodes the data.
 func (e *Exit) Marshal() ([]byte, error) {
-	return ssz.Marshal(e)
+	b, err := ssz.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (e *Exit) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, e)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, e)
 }
 
 // Hash calculates the hash of the exit.

--- a/primitives/governance.go
+++ b/primitives/governance.go
@@ -130,7 +130,11 @@ func (c *CommunityVoteData) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (c *CommunityVoteData) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, c)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, c)
 }
 
 // Copy copies the community vote data.
@@ -195,7 +199,11 @@ func (gv *GovernanceVote) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (gv *GovernanceVote) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, gv)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, gv)
 }
 
 func (gv *GovernanceVote) Valid() bool {

--- a/primitives/governance.go
+++ b/primitives/governance.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	fastssz "github.com/ferranbt/fastssz"
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
@@ -35,12 +36,20 @@ type Governance struct {
 
 // Marshal serializes the struct to bytes
 func (g *Governance) Marshal() ([]byte, error) {
-	return ssz.Marshal(g)
+	b, err := ssz.Marshal(g)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal deserialize the bytes to a struct
 func (g *Governance) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, g)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, g)
 }
 
 // MarshalSSZ overrides the ssz function using fastssz interface
@@ -112,7 +121,11 @@ type CommunityVoteData struct {
 
 // Marshal encodes the data.
 func (c *CommunityVoteData) Marshal() ([]byte, error) {
-	return ssz.Marshal(c)
+	b, err := ssz.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
@@ -173,7 +186,11 @@ func (gv *GovernanceVote) Signature() (bls.FunctionalSignature, error) {
 
 // Marshal encodes the data.
 func (gv *GovernanceVote) Marshal() ([]byte, error) {
-	return ssz.Marshal(gv)
+	b, err := ssz.Marshal(gv)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/primitives/slashing.go
+++ b/primitives/slashing.go
@@ -25,7 +25,11 @@ func (vs *VoteSlashing) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (vs *VoteSlashing) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, vs)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, vs)
 }
 
 // Hash calculates the hash of the slashing.
@@ -61,7 +65,11 @@ func (rs *RANDAOSlashing) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (rs *RANDAOSlashing) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, rs)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, rs)
 }
 
 // Hash calculates the hash of the RANDAO slashing.
@@ -103,7 +111,11 @@ func (ps *ProposerSlashing) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (ps *ProposerSlashing) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, ps)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, ps)
 }
 
 // Hash calculates the hash of the proposer slashing.

--- a/primitives/slashing.go
+++ b/primitives/slashing.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
@@ -15,7 +16,11 @@ type VoteSlashing struct {
 
 // Marshal encodes the data.
 func (vs *VoteSlashing) Marshal() ([]byte, error) {
-	return ssz.Marshal(vs)
+	b, err := ssz.Marshal(vs)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
@@ -47,7 +52,11 @@ func (rs *RANDAOSlashing) GetRandaoReveal() (*bls.Signature, error) {
 
 // Marshal encodes the data.
 func (rs *RANDAOSlashing) Marshal() ([]byte, error) {
-	return ssz.Marshal(rs)
+	b, err := ssz.Marshal(rs)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
@@ -85,7 +94,11 @@ func (ps *ProposerSlashing) GetSignature2() (*bls.Signature, error) {
 
 // Marshal encodes the data.
 func (ps *ProposerSlashing) Marshal() ([]byte, error) {
-	return ssz.Marshal(ps)
+	b, err := ssz.Marshal(ps)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.

--- a/primitives/tx.go
+++ b/primitives/tx.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/utils/chainhash"
 	"github.com/prysmaticlabs/go-ssz"
@@ -48,12 +48,20 @@ func (c TransferSinglePayload) FromPubkeyHash() (out [20]byte, err error) {
 
 // Marshal encodes the data.
 func (c *TransferSinglePayload) Marshal() ([]byte, error) {
-	return ssz.Marshal(c)
+	b, err := ssz.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (c *TransferSinglePayload) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, c)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, c)
 }
 
 // SignatureMessage gets the message the needs to be signed.
@@ -130,7 +138,11 @@ type TransferMultiPayload struct {
 
 // Marshal encodes the data.
 func (c *TransferMultiPayload) Marshal() ([]byte, error) {
-	return ssz.Marshal(c)
+	b, err := ssz.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
@@ -214,12 +226,6 @@ var _ TxPayload = &TransferMultiPayload{}
 // GenesisPayload is the payload of the genesis transaction.
 type GenesisPayload struct{}
 
-// Encode does nothing for the genesis payload.
-func (g *GenesisPayload) Encode(w io.Writer) error { return nil }
-
-// Decode does nothing for the genesis payload.
-func (g *GenesisPayload) Decode(r io.Reader) error { return nil }
-
 // TxPayload represents anything that can be used as a payload in a transaction.
 type TxPayload interface {
 	Marshal() ([]byte, error)
@@ -264,12 +270,20 @@ func (t *Tx) AppendPayload(p TxPayload) error {
 
 // Marshal encodes the data.
 func (t *Tx) Marshal() ([]byte, error) {
-	return ssz.Marshal(t)
+	b, err := ssz.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (t *Tx) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, t)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, t)
 }
 
 // Hash calculates the transaction hash.

--- a/primitives/tx.go
+++ b/primitives/tx.go
@@ -147,7 +147,11 @@ func (c *TransferMultiPayload) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (c *TransferMultiPayload) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, c)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, c)
 }
 
 // Hash calculates the transaction ID of the payload.

--- a/primitives/validator.go
+++ b/primitives/validator.go
@@ -1,6 +1,7 @@
 package primitives
 
 import (
+	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
 )
 
@@ -65,12 +66,20 @@ func (wr *Validator) IsActiveAtEpoch(epoch uint64) bool {
 
 // Marshal encodes the data.
 func (v *Validator) Marshal() ([]byte, error) {
-	return ssz.Marshal(v)
+	b, err := ssz.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (v *Validator) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, v)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, v)
 }
 
 // Copy returns a copy of the validator.

--- a/primitives/votes.go
+++ b/primitives/votes.go
@@ -3,6 +3,7 @@ package primitives
 import (
 	"fmt"
 
+	"github.com/golang/snappy"
 	"github.com/olympus-protocol/ogen/bls"
 	"github.com/olympus-protocol/ogen/params"
 	"github.com/prysmaticlabs/go-ssz"
@@ -31,12 +32,20 @@ type AcceptedVoteInfo struct {
 
 // Marshal encodes the data.
 func (av *AcceptedVoteInfo) Marshal() ([]byte, error) {
-	return ssz.Marshal(av)
+	b, err := ssz.Marshal(av)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (av *AcceptedVoteInfo) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, av)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, av)
 }
 
 // Copy returns a copy of the AcceptedVoteInfo.
@@ -81,12 +90,20 @@ type VoteData struct {
 
 // Marshal encodes the data.
 func (v *VoteData) Marshal() ([]byte, error) {
-	return ssz.Marshal(v)
+	b, err := ssz.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (v *VoteData) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, v)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, v)
 }
 
 func (v *VoteData) FirstSlotValid(p *params.ChainParams) uint64 {
@@ -153,12 +170,20 @@ func (v *SingleValidatorVote) Signature() (*bls.Signature, error) {
 
 // Marshal encodes the data.
 func (v *SingleValidatorVote) Marshal() ([]byte, error) {
-	return ssz.Marshal(v)
+	b, err := ssz.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (v *SingleValidatorVote) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, v)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, v)
 }
 
 // AsMulti returns the single validator vote as a multi validator vote.
@@ -191,12 +216,20 @@ func (v *MultiValidatorVote) Signature() (*bls.Signature, error) {
 
 // Marshal encodes the data.
 func (v *MultiValidatorVote) Marshal() ([]byte, error) {
-	return ssz.Marshal(v)
+	b, err := ssz.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return snappy.Encode(nil, b), nil
 }
 
 // Unmarshal decodes the data.
 func (v *MultiValidatorVote) Unmarshal(b []byte) error {
-	return ssz.Unmarshal(b, v)
+	d, err := snappy.Decode(nil, b)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(d, v)
 }
 
 // Hash calculates the hash of the vote.

--- a/proposer/proposer.go
+++ b/proposer/proposer.go
@@ -152,7 +152,7 @@ func (p *Proposer) ProposeBlocks() {
 			//if p.chain.State().Tip().Slot+p.params.EpochLength < slotToPropose {
 			//	p.log.Infof("blockchain not synced... trying to mine in 10 seconds")
 
-				// wait 10 seconds before starting the next vote
+			// wait 10 seconds before starting the next vote
 			//	blockTimer = time.NewTimer(time.Second * 10)
 			//	continue
 			//}
@@ -285,7 +285,7 @@ func (p *Proposer) VoteForBlocks() {
 			//if p.chain.State().Tip().Slot+p.params.EpochLength < slotToVote {
 			//	p.log.Infof("blockchain not synced... trying to mine in 10 seconds")
 
-				// wait 10 seconds before starting the next vote
+			// wait 10 seconds before starting the next vote
 			//	voteTimer = time.NewTimer(time.Second * 10)
 			//	continue
 			//}

--- a/utils/bitfield/bitfield.go
+++ b/utils/bitfield/bitfield.go
@@ -1,6 +1,9 @@
 package bitfield
 
-import "github.com/prysmaticlabs/go-ssz"
+import (
+	"github.com/golang/snappy"
+	"github.com/prysmaticlabs/go-ssz"
+)
 
 // Bitfield is a bitfield of a certain length.
 type Bitfield []byte
@@ -32,7 +35,11 @@ func (b Bitfield) Marshal() ([]byte, error) {
 
 // Unmarshal decodes the data.
 func (b Bitfield) Unmarshal(by []byte) error {
-	return ssz.Unmarshal(by, b)
+	de, err := snappy.Decode(nil, by)
+	if err != nil {
+		return err
+	}
+	return ssz.Unmarshal(de, b)
 }
 
 // Copy returns a copy of the bitfield.


### PR DESCRIPTION
# Description

To reduce hard disk storage and network bandwith all the primitives and messages are now encoded using the snappy library.

