### PR TITLE
Fixes to mysql table creation and structure

### DIFF
--- a/cmd/ogen/indexer/db/migrations/mysql/000001_initialize.up.sql
+++ b/cmd/ogen/indexer/db/migrations/mysql/000001_initialize.up.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `blocks` (
 CREATE TABLE IF NOT EXISTS `block_headers` (
     `block_hash` binary(64) NOT NULL,
     `version` INT NOT NULL,
-    `nonce` INT NOT NULL,
+    `nonce` BIGINT NOT NULL,
     `tx_merkle_root` binary(64) NOT NULL,
     `tx_multi_merkle_root` binary(64) NOT NULL,
     `vote_merkle_root` binary(64) NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `block_headers` (
     `slot` INT NOT NULL,
     `state_root` binary(64) NOT NULL,
     `fee_address` binary(40) NOT NULL,
-    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC) VISIBLE,
+    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC),
     CONSTRAINT `block_hash`
         FOREIGN KEY (`block_hash`)
             REFERENCES `blocks` (`block_hash`)
@@ -44,13 +44,14 @@ CREATE TABLE IF NOT EXISTS `votes` (
     `data_to_epoch` INT NOT NULL,
     `data_to_hash` binary(64) NOT NULL,
     `data_beacon_block_hash` binary(64) NOT NULL,
-    `data_nonce` INT NOT NULL,
+    `data_nonce` BIGINT NOT NULL,
     `vote_hash` binary(64) NOT NULL,
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `deposits` (
     `block_hash` binary(64) NOT NULL,
     `public_key` BINARY(96) NOT NULL,
@@ -58,22 +59,24 @@ CREATE TABLE IF NOT EXISTS `deposits` (
     `data_public_key` BINARY(96) NOT NULL,
     `data_proof_of_possession` binary(192) NOT NULL,
     `data_withdrawal_address` binary(40) NOT NULL,
-    UNIQUE INDEX `data_public_key_UNIQUE` (`data_public_key` ASC) VISIBLE,
-    UNIQUE INDEX `data_proof_of_possession_UNIQUE` (`data_proof_of_possession` ASC) VISIBLE,
+    UNIQUE INDEX `data_public_key_UNIQUE` (`data_public_key` ASC),
+    UNIQUE INDEX `data_proof_of_possession_UNIQUE` (`data_proof_of_possession` ASC),
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `accounts` (
     `account` binary(40) NOT NULL,
-    `confirmed` INT DEFAULT 0,
-    `unconfirmed` INT DEFAULT 0,
-    `locked`INT DEFAULT 0,
-    `total_sent` INT DEFAULT 0,
-    `total_received`INT DEFAULT 0,
-    UNIQUE INDEX `account_UNIQUE` (`account` ASC) VISIBLE
+    `confirmed` BIGINT DEFAULT 0,
+    `unconfirmed` BIGINT DEFAULT 0,
+    `locked` BIGINT DEFAULT 0,
+    `total_sent` BIGINT DEFAULT 0,
+    `total_received` BIGINT DEFAULT 0,
+    UNIQUE INDEX `account_UNIQUE` (`account` ASC)
 );
+
 CREATE TABLE IF NOT EXISTS `validators` (
     `id` INT NOT NULL AUTO_INCREMENT,
     `public_key` BINARY(96) NOT NULL,
@@ -81,49 +84,53 @@ CREATE TABLE IF NOT EXISTS `validators` (
     `penalized` BOOLEAN NOT NULL,
     PRIMARY KEY (`id`)
 );
+
 CREATE TABLE IF NOT EXISTS `exits` (
     `block_hash` binary(64) NOT NULL,
     `validator_public_key` binary(192) NOT NULL,
-    `withdrawal_public_key` binary(40) NOT NULL,
+    `withdrawal_public_key` binary(96) NOT NULL,
     `signature` binary(192) NOT NULL,
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `tx_single` (
     `hash` binary(64) NOT NULL,
     `block_hash` binary(64) NOT NULL,
     `tx_type` INT NOT NULL,
     `to_addr` BINARY(40) NOT NULL,
     `from_public_key` BINARY(96) NOT NULL,
-    `amount` INT NOT NULL,
-    `nonce` INT NOT NULL,
-    `fee` INT NOT NULL,
+    `amount` BIGINT NOT NULL,
+    `nonce` BIGINT NOT NULL,
+    `fee` BIGINT NOT NULL,
     `signature` binary(192) NOT NULL,
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `vote_slashing` (
     `block_hash` binary(64) NOT NULL,
     `vote_1` binary(64) NOT NULL,
     `vote_2` binary(64) NOT NULL,
     PRIMARY KEY (`block_hash`, `vote_1`, `vote_2`),
-    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC) VISIBLE,
+    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC),
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `randao_slashing` (
     `block_hash` binary(64) NOT NULL,
     `randao_reveal` binary(192) NOT NULL,
     `slot` INT NOT NULL,
     `validator_public_key` BINARY(96) NOT NULL,
     PRIMARY KEY (`block_hash`),
-    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC) VISIBLE,
+    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC),
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION
@@ -133,6 +140,7 @@ CREATE TABLE IF NOT EXISTS `randao_slashing` (
         ON DELETE NO ACTION
         ON UPDATE NO ACTION
 );
+
 CREATE TABLE IF NOT EXISTS `proposer_slashing` (
     `block_hash` binary(64) NOT NULL,
     `blockheader_1` binary(64) NOT NULL,
@@ -141,7 +149,7 @@ CREATE TABLE IF NOT EXISTS `proposer_slashing` (
     `signature_2` binary(192) NOT NULL,
     `validator_public_key` BINARY(96) NOT NULL,
     PRIMARY KEY (`block_hash`),
-    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC) VISIBLE,
+    UNIQUE INDEX `block_hash_UNIQUE` (`block_hash` ASC),
     FOREIGN KEY (`block_hash`)
         REFERENCES `blocks` (`block_hash`)
         ON DELETE NO ACTION


### PR DESCRIPTION
Indexes are VISIBLE by default, removed VISIBLE keywords out of all table creation statements to fix syntax.

Changed size of amount holding fields to BIGINT to allow 8 digit precision storage without overflows.

Fixed init of nonces to BIGINT to avoid overflow

Fixed size of withdrawal_public_key 