### PR TITLE
Hermes develop

### DIFF
--- a/cmd/ogen/commands/indexer.go
+++ b/cmd/ogen/commands/indexer.go
@@ -35,13 +35,13 @@ var indexerCmd = &cobra.Command{
 
 		var netParams *params.ChainParams
 		switch network {
-		case "testnet":
-			netParams = &params.TestNet
-		case "mainnet":
-			netParams = &params.MainNet
-		default:
-			fmt.Println("unknown network parameters")
-			os.Exit(0)
+			case "testnet":
+				netParams = &params.TestNet
+			case "mainnet":
+				netParams = &params.MainNet
+			default:
+				fmt.Println("unknown network parameters")
+				os.Exit(0)
 		}
 
 		if dbConnString == "" {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"sync"
 	"time"
+	"errors"
 )
 
 // Indexer is the module that allows operations across multiple services.
@@ -79,9 +80,23 @@ func (i *Indexer) ProcessBlock(b *primitives.Block) (*chainindex.BlockRow, error
 	}
 
 	tip, _ := i.index.Get(b.Header.PrevBlockHash)
+
+	/* This double check it-s made since the Feb/21 indexer problem, when it crashed while 
+	trying to sync all the blocks. 
+
+	As the result from get function can be a null BlockRow object, we need to confirm we
+	have a valid tip variable obtained with the previous block hash.
+
+	If the result is null, we return a null BlockRow and a new error to be processed later */
+	if tip == nil {
+		return nil, errors.New("the tip calculated with the given primitives blocks PrevBlockHash is null.\n"+
+					  "please review the blocks and chain hash info");
+	}
+
 	v := chain.NewChainView(tip)
 
 	_, err = i.state.ProcessSlots(b.Header.Slot, &v)
+
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +114,7 @@ func (i *Indexer) ProcessBlock(b *primitives.Block) (*chainindex.BlockRow, error
 		return nil, err
 	}
 
-	if b.Header.Slot/i.netParams.EpochLength > i.state.GetEpochIndex() {
+	if b.Header.Slot / i.netParams.EpochLength > i.state.GetEpochIndex() {
 		serState := i.state.ToSerializable()
 
 		// Mark justified and finalized

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -89,8 +89,10 @@ func (i *Indexer) ProcessBlock(b *primitives.Block) (*chainindex.BlockRow, error
 
 	If the result is null, we return a null BlockRow and a new error to be processed later */
 	if tip == nil {
+		i.log.Infof("The tip calculated with the given primitives blocks PrevBlockHash: ", b.Header.PrevBlockHash,
+					" is null. Please review the blocks and chain hash info")
 		return nil, errors.New("the tip calculated with the given primitives blocks PrevBlockHash is null.\n"+
-					  "please review the blocks and chain hash info");
+					  "Please review the blocks and chain hash info");
 	}
 
 	v := chain.NewChainView(tip)


### PR DESCRIPTION
# Description

On the internal/indexer/indexer.go file, right after the tip var was set, on the ProcessBlock function; a double check was added to ensure the BlockRow received by the i.index.Get(b.Header.PrevBlockHash) call is not null and doesn't generate the SIGSEGV when trying to access a null pointer field.

Extra tracing was added to indicate where the problem was originated and as a suggested solution; after finding this null reference a null value and an error was returned as the result of the function to keep scanning for new blocks with valid references.

Or maybe, it can be generated by the go routines problems with concurrency; but as this problem is only generated on a certain set of the last blocks scanned, then this idea is subject to be discarded. 

Fixes # (Indexer SIGSEGV when processing blocks)

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)


# Checklist:
- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my own code.
- [ X ] I have commented my code, particularly in hard-to-understand areas.
- [ X ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added unit tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.